### PR TITLE
Update go.mod to match repos name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nailuj29gaming/wren-web
+module github.com/wren-web/wren-web
 
 go 1.16
 


### PR DESCRIPTION
Update go.mod to match repos name. This should allow one liner installs like this: `go install github.com/wren-web/wren-web@latest`